### PR TITLE
Preserve score sum when inverting scores

### DIFF
--- a/lib/genetic/Task.js
+++ b/lib/genetic/Task.js
@@ -232,14 +232,25 @@ Task.prototype.reproduction = function (callback) {
                 position++
                 level+=self.parents[position].score
               }
-              child = JSON.parse(JSON.stringify(self.parents[position]))
               
               parent = self.parents[position]
               secondParentPosition = position
               secondParent = self.parents[secondParentPosition]    
               if (Math.random() < self.crossoverProbability) {
                 self.emit('crossover')
-                secondParentPosition = Math.floor(Math.random()*self.parents.length)
+
+                if (Math.random() < .5) {
+                  secondParentPosition = Math.floor(Math.random()*self.parents.length)
+                } else {
+                  point = Math.random()*sum
+                  secondParentPosition = 0
+                  level = self.parents[secondParentPosition].score
+                  while (point>level) {
+                    secondParentPosition++
+                    level+=self.parents[secondParentPosition].score
+                  }
+                }
+
                 secondParent = self.parents[secondParentPosition]    
               }
               self.crossover(self.parents[position], secondParent, function (child) {


### PR DESCRIPTION
When looking for minimized fitness, score sum of all chromosomes should maintain the same when inverting the scores, so that the normalized fitness can work.

Particularly, if the sum becomes smaller after inverting scores, then on line 206 there is a chance that `level` might never reach `point`, if `point` happens to be greater than the new sum.

I am using another method of inverting the score which maintains the sum of scores at the same time.
