### PR TITLE
Preserve Score Sum When Inverting Scores

### DIFF
--- a/lib/genetic/Task.js
+++ b/lib/genetic/Task.js
@@ -173,12 +173,11 @@ Task.prototype.reproduction = function (callback) {
       }
       , function (callback) {
         // invert scores, if we minimize fitness
-        var maxScore = Math.abs(self.statistics.maxScore)
+        var avg = self.statistics.avg
         if (self.minimize) {
           async.forEach(self.parents
             , function (item, cb) {
-              item.score*=-1
-              item.score+=maxScore
+              item.score = avg * 2 - item.score
               process.nextTick(function () {cb()})
             }
             , function (err) {


### PR DESCRIPTION
When looking for minimized fitness, score sum of all chromosomes should maintain the same when inverting the scores, so that the normalized fitness can work.

Particularly, if the sum becomes smaller after inverting scores, then on line 206 there is a chance that `level` might never reach `point`, if `point` happens to be greater than the new sum.

I am using another method of inverting the score which maintains the sum of scores at the same time.
