### PR TITLE
recalculate sum when inverting scores

### DIFF
--- a/lib/genetic/Task.js
+++ b/lib/genetic/Task.js
@@ -173,12 +173,14 @@ Task.prototype.reproduction = function (callback) {
       }
       , function (callback) {
         // invert scores, if we minimize fitness
+        sum = 0
         var maxScore = Math.abs(self.statistics.maxScore)
         if (self.minimize) {
           async.forEach(self.parents
             , function (item, cb) {
               item.score*=-1
               item.score+=maxScore
+              sum+=item.score;
               setImmediate(function () {cb()})
             }
             , function (err) {


### PR DESCRIPTION
Sum should be recalculated after inverting scores as sum is not the same anymore. Application crashes when adding new scores until it reaches _level_ (which is between 0 and sum, where sum is greater then actual sum), because of "IndexOutOfBoundsException".
