### PR TITLE
Multiple instances of Task are using the same Event Emitter

### DIFF
--- a/lib/genetic/Task.js
+++ b/lib/genetic/Task.js
@@ -12,6 +12,7 @@ function Task(options) {
   this.crossoverProbability = options.crossoverProbability
   this.crossover = options.crossover
   this.minimize = false || options.minimize
+  EventEmitter.call(this);
 }
 
 Task.prototype = new EventEmitter()


### PR DESCRIPTION
```
const task1 = new Task(options);
const task2 = new Task(options);
task1.on('statistics', () => { console.log('task1-handler'); })
task2.on('statistics', () => { console.log('task2-handler'); })
```
When you run the Task `task1.run` and then `task2.run`
You will get: 
```
task1-handler
task2-handler
task1-handler
task2-handler
```

instead of 
```
task1-handler
task2-handler
```

This PR fixes the issue